### PR TITLE
Read parameters from JSON string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## [[unpublished]](https://github.com/mlange-42/beecs/compare/v0.2.0...main)
 
+### Breaking changes
+
+* `FromJSON` for default and custom parameters renamed to `FromJSONFile` (#77)
+
 ### Features
 
 - Adds option to terminate on extinction of all bees (#75)
 - Adds observer `Extinction` to report the tick of colony extinction (#76)
+- Adds `FromJSON([]byte)` for default and custom parameters (#77)
 
 ### Documentation
 

--- a/_examples/json_parameters/main.go
+++ b/_examples/json_parameters/main.go
@@ -15,7 +15,7 @@ func main() {
 	// Get the default parameters.
 	p := params.Default()
 	// Read JSON to modify some parameters.
-	err := p.FromJSON("_examples/json_parameters/params.json")
+	err := p.FromJSONFile("_examples/json_parameters/params.json")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/params/custom.go
+++ b/params/custom.go
@@ -38,24 +38,32 @@ type customParamsJs struct {
 	Custom     map[string]entry
 }
 
-// FromJSON fills the parameter set with values from a JSON file.
+// FromJSONFile fills the parameter set with values from a JSON file.
 //
 // Only values present in the file are overwritten,
 // all other values remain unchanged.
-func (p *CustomParams) FromJSON(path string) error {
-	file, err := os.Open(path)
+func (p *CustomParams) FromJSONFile(path string) error {
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
-	decoder := json.NewDecoder(file)
+	return p.FromJSON(content)
+}
+
+// FromJSON fills the parameter set with values from JSON.
+//
+// Only values present in the file are overwritten,
+// all other values remain unchanged.
+func (p *CustomParams) FromJSON(data []byte) error {
+	reader := bytes.NewReader(data)
+	decoder := json.NewDecoder(reader)
 	decoder.DisallowUnknownFields()
 
 	pars := customParamsJs{
 		Parameters: p.Parameters,
 	}
-	err = decoder.Decode(&pars)
+	err := decoder.Decode(&pars)
 	if err != nil {
 		return err
 	}

--- a/params/custom_test.go
+++ b/params/custom_test.go
@@ -1,0 +1,47 @@
+package params_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mlange-42/beecs/params"
+	"github.com/mlange-42/beecs/registry"
+	"github.com/stretchr/testify/assert"
+)
+
+type CustomParam struct {
+	Value int
+}
+
+func TestCustomParamsFromJSON(t *testing.T) {
+	registry.RegisterResource[CustomParam]()
+
+	p := params.CustomParams{}
+
+	js := `{
+    "Parameters": {
+        "Termination": {
+            "MaxTicks": 3650,
+            "OnExtinction": true
+        }
+    },
+	"Custom": {
+		"params_test.CustomParam": {
+			"Value": 100
+		}
+	}
+}`
+
+	err := p.FromJSON([]byte(js))
+	assert.Nil(t, err)
+
+	assert.Equal(t, 3650, p.Parameters.Termination.MaxTicks)
+
+	obj, ok := p.Custom[reflect.TypeOf(CustomParam{})]
+	assert.True(t, ok)
+
+	par, ok := obj.(*CustomParam)
+	assert.True(t, ok)
+
+	assert.Equal(t, 100, par.Value)
+}

--- a/params/default.go
+++ b/params/default.go
@@ -1,6 +1,7 @@
 package params
 
 import (
+	"bytes"
 	"encoding/json"
 	"math/rand"
 	"os"
@@ -15,7 +16,9 @@ type Params interface {
 	// Apply the parameters to a world.
 	Apply(world *ecs.World)
 	// FromJSON fills the parameter set with values from a JSON file.
-	FromJSON(path string) error
+	FromJSONFile(path string) error
+	// FromJSON fills the parameter set with values from a JSON file.
+	FromJSON(data []byte) error
 }
 
 // DefaultParams contains all default parameters of BEEHAVE.
@@ -198,18 +201,26 @@ func Default() DefaultParams {
 	}
 }
 
-// FromJSON fills the parameter set with values from a JSON file.
+// unchanged fills the parameter set with values from a JSON file.
 //
 // Only values present in the file are overwritten,
 // all other values remain unchanged.
-func (p *DefaultParams) FromJSON(path string) error {
-	file, err := os.Open(path)
+func (p *DefaultParams) FromJSONFile(path string) error {
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
-	decoder := json.NewDecoder(file)
+	return p.FromJSON(content)
+}
+
+// FromJSON fills the parameter set with values from JSON.
+//
+// Only values present in the file are overwritten,
+// all other values remain unchanged.
+func (p *DefaultParams) FromJSON(data []byte) error {
+	reader := bytes.NewReader(data)
+	decoder := json.NewDecoder(reader)
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(p)
 }

--- a/params/default_test.go
+++ b/params/default_test.go
@@ -1,0 +1,24 @@
+package params_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/beecs/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultParamsFromJSON(t *testing.T) {
+	p := params.Default()
+
+	js := `{
+    "Termination": {
+        "MaxTicks": 3650,
+        "OnExtinction": true
+    }
+}`
+
+	err := p.FromJSON([]byte(js))
+	assert.Nil(t, err)
+
+	assert.Equal(t, 3650, p.Termination.MaxTicks)
+}


### PR DESCRIPTION
* `FromJSON` for default and custom parameters renamed to `FromJSONFile`
* Adds `FromJSON([]byte)` for default and custom parameters

See [params/default_test.go](https://github.com/mlange-42/beecs/pull/77/files#diff-88cd24616c88f28f7db8c070c085a4407dca076f9079a38b643b17ddc94917fb) for usage.