### PR TITLE
Rename misspelled parameter `EnergyContent.Scurose` to `Sucrose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [[unpublished]](https://github.com/mlange-42/beecs/compare/v0.5.0...main)
+
+### Breaking changes
+
+* Renames misspelled parameter `EnergyContent.Scurose` to `Sucrose` (#85)
+
 ## [[v0.5.0]](https://github.com/mlange-42/beecs/compare/v0.4.1...v0.5.0)
 
 ### Features

--- a/params/default.go
+++ b/params/default.go
@@ -134,7 +134,7 @@ func Default() DefaultParams {
 		},
 		EnergyContent: EnergyContent{
 			Honey:   12.78,
-			Scurose: 0.00582,
+			Sucrose: 0.00582,
 		},
 		Stores: Stores{
 			IdealPollenStoreDays: 7,

--- a/params/parameters.go
+++ b/params/parameters.go
@@ -115,7 +115,7 @@ type DroneMortality struct {
 // EnergyContent parameters.
 type EnergyContent struct {
 	Honey   float64 // Energy content of honey [kJ/g].
-	Scurose float64 // Energy content of sucrose [kJ/micromol].
+	Sucrose float64 // Energy content of sucrose [kJ/micromol].
 }
 
 // HoneyNeeds parameters.

--- a/sys/foraging.go
+++ b/sys/foraging.go
@@ -194,7 +194,7 @@ func (s *Foraging) updatePatches(w *ecs.World) {
 			(s.foragerParams.FlightCostPerM * ht.Pollen *
 				s.foragerParams.FlightVelocity * s.forageParams.EnergyOnFlower) // [kJ] = [m*kJ/m + kJ/m * s * m/s]
 
-		r.EnergyEfficiency = (conf.NectarConcentration*s.foragerParams.NectarLoad*s.energyParams.Scurose - trip.CostNectar) / trip.CostNectar
+		r.EnergyEfficiency = (conf.NectarConcentration*s.foragerParams.NectarLoad*s.energyParams.Sucrose - trip.CostNectar) / trip.CostNectar
 
 		trip.DurationNectar = 2*dist.DistToColony/s.foragerParams.FlightVelocity + ht.Nectar
 		trip.DurationPollen = 2*dist.DistToColony/s.foragerParams.FlightVelocity + ht.Pollen
@@ -419,7 +419,7 @@ func (s *Foraging) collecting(w *ecs.World) {
 
 		if act.Current == activity.BringNectar {
 			conf, trip := s.patchConfigMapper.Get(patch.Nectar)
-			load.Energy = conf.NectarConcentration * s.foragerParams.NectarLoad * s.energyParams.Scurose
+			load.Energy = conf.NectarConcentration * s.foragerParams.NectarLoad * s.energyParams.Sucrose
 			dist := trip.CostNectar / (s.foragerParams.FlightCostPerM * 1000)
 			milage.Today += float32(dist)
 			milage.Total += float32(dist)

--- a/sys/honey_consumption_test.go
+++ b/sys/honey_consumption_test.go
@@ -52,7 +52,7 @@ func TestHoneyConsumption(t *testing.T) {
 
 	ecs.AddResource(&world, &params.EnergyContent{
 		Honey:   12.78,
-		Scurose: 0.00582,
+		Sucrose: 0.00582,
 	})
 	ecs.AddResource(&world, &params.Nursing{
 		MaxBroodNurseRatio: 3.0,

--- a/sys/pollen_consumption_test.go
+++ b/sys/pollen_consumption_test.go
@@ -47,7 +47,7 @@ func TestPollenConsumption(t *testing.T) {
 
 	ecs.AddResource(&world, &params.EnergyContent{
 		Honey:   12.78,
-		Scurose: 0.00582,
+		Sucrose: 0.00582,
 	})
 	ecs.AddResource(&world, &params.Nursing{
 		MaxBroodNurseRatio: 3.0,


### PR DESCRIPTION
Fixes #84 